### PR TITLE
translate docs/gatsby-cli 

### DIFF
--- a/docs/docs/gatsby-cli.md
+++ b/docs/docs/gatsby-cli.md
@@ -1,20 +1,20 @@
 ---
-title: Commands (Gatsby CLI)
+title: Команды (Gatsby CLI)
 ---
 
 # gatsby-cli
 
-The Gatsby command line tool (CLI) is the main entry point for getting up and running with a Gatsby application and for using functionality including like running a development server and building out your Gatsby application for deployment.
+Инструмент командной строки Gatsby (CLI) является основной точкой входа для начала работы с приложением Gatsby и для использования таких функций, как запуск сервера разработки и сборка вашего приложения Gatsby для развёртывания.
 
-_We provide similar documentation available with the gatsby-cli [README](https://github.com/gatsbyjs/gatsby/blob/master/packages/gatsby-cli/README.md), and our [cheat sheet](/docs/cheat-sheet/) has all the top CLI commands ready to print out._
+_Мы предоставляем аналогичную документацию, доступную с gatsby-cli [README](https://github.com/gatsbyjs/gatsby/blob/master/packages/gatsby-cli/README.md), и наша [шпаргалка](/docs/cheat-sheet/) содержит все основные команды CLI, готовые к печати._
 
-## How to use
+## Как использовать
 
-The Gatsby CLI (`gatsby-cli`) is packaged as an executable that can be used globally. The Gatsby CLI is available via [npm](https://www.npmjs.com/) and should be installed globally by running `npm install -g gatsby-cli` to use it locally.
+Gatsby CLI (`gatsby-cli`) упакован как исполняемый файл, который можно использовать глобально. Gatsby CLI доступен через [npm](https://www.npmjs.com/) и должен быть установлен глобально с помощью команды `npm install -g gatsby-cli` для использования локально.
 
-Run `gatsby --help` for full help.
+Выполните команду `gatsby --help` чтобы увидеть подсказки по всем командам.
 
-You can also use the `package.json` script variant of these commands, typically exposed _for you_ with most [starters](/docs/starters/). For example, if we want to make the [`gatsby develop`](#develop) command available in our application, we would open up `package.json` and add a script like so:
+Вы также можете использовать скриптовый вариант этих команд в `package.json`, который обычно доступен _для вас_ с большинством [стартеров](/docs/starters/). Например, если мы хотим сделать команду [`gatsby develop`](#develop) доступной в нашем приложении, мы откроем `package.json` и добавим скрипт подобный:
 
 ```json:title=package.json
 {
@@ -28,36 +28,36 @@ You can also use the `package.json` script variant of these commands, typically 
 
 `gatsby new gatsby-site`
 
-See the [Gatsby starters docs](/docs/starters/)
-for a comprehensive list of starters to get started with Gatsby.
+Смотрите [документацию стартеров Gatsby](/docs/starters/)
+с полным списком стартеров, чтобы начать использовать Gatsby.
 
 ### `develop`
 
-Once you've installed a Gatsby site, go to the root directory of your project and start the development server:
+Установив сайт Gatsby, перейдите в корневой каталог вашего проекта и запустите сервер разработки:
 
 `gatsby develop`
 
-#### Options
+#### Опции
 
-|     Option      | Description                                     |
+|     Опция       | Описание                                        |
 | :-------------: | ----------------------------------------------- |
-| `-H`, `--host`  | Set host. Defaults to localhost                 |
-| `-p`, `--port`  | Set port. Defaults to 8000                      |
-| `-o`, `--open`  | Open the site in your (default) browser for you |
-| `-S`, `--https` | Use HTTPS                                       |
+| `-H`, `--host`  | Установить хост. По умолчанию localhost         |
+| `-p`, `--port`  | Установить порт. По умолчанию 8000              |
+| `-o`, `--open`  | Открыть сайт в вашем браузере (по умолчанию)    |
+| `-S`, `--https` | Использовать HTTPS                              |
 
-Follow the [Local HTTPS guide](/docs/local-https/)
-to find out how you can set up an HTTPS development server using Gatsby.
+Следуйте [инструкции Local HTTPS](/docs/local-https/)
+чтобы узнать, как настроить сервер разработки HTTPS с помощью Gatsby.
 
-#### Preview changes on other devices
+#### Предварительный просмотр изменений на других устройствах
 
-You can use the Gatsby develop command with the host option to access your dev environment on other devices on the same network, run:
+Вы можете использовать команду Gatsby develop с опцией host для доступа к вашей среде разработки на других устройствах в той же сети, запустите:
 
 ```shell
 gatsby develop -H 0.0.0.0
 ```
 
-Then the terminal will log information as usual, but will additionally include a URL that you can navigate to from a client on the same network to see how the site renders.
+Затем терминал будет регистрировать информацию, как обычно, но дополнительно будет включать URL, по которому вы можете перейти от клиента в той же сети, чтобы увидеть, как отображается сайт.
 
 ```
 You can now view gatsbyjs.org in the browser.
@@ -66,82 +66,82 @@ You can now view gatsbyjs.org in the browser.
   On Your Network:  http://192.168.0.212:8000/ // highlight-line
 ```
 
-**Note**: you can't visit 0.0.0.0:8000 on Windows (but things will work using either localhost:8000 or the "On Your Network" URL on Windows)
+**Примечание**: вы не можете посетить 0.0.0.0:8000 в Windows (но всё будет работать с использованием localhost:8000 или "On Your Network" URL в Windows)
 
 ### `build`
 
-At the root of a Gatsby site, compile your application and make it ready for deployment:
+В корневом каталоге сайта Gatsby, скомпилируйте своё приложение и подготовьте его к развёртыванию:
 
 `gatsby build`
 
-#### Options
+#### Опции
 
-|            Option            | Description                                                                                               |
-| :--------------------------: | --------------------------------------------------------------------------------------------------------- |
-|       `--prefix-paths`       | Build site with link paths prefixed (set pathPrefix in your config)                                       |
-|        `--no-uglify`         | Build site without uglifying JS bundles (for debugging)                                                   |
-| `--open-tracing-config-file` | Tracer configuration file (OpenTracing compatible). See [Performance Tracing](/docs/performance-tracing/) |
-| `--no-color`, `--no-colors`  | Disables colored terminal output                                                                          |
+|            Опция             | Описание                                                                                                                            |
+| :--------------------------: | ----------------------------------------------------------------------------------------------------------------------------------- |
+|       `--prefix-paths`       | Создать сайт с префиксами путей ссылки (установите pathPrefix в вашей конфигурации)                                                 |
+|        `--no-uglify`         | Создать сайт без аглификации (сжатия) JS бандлов (для отладки)                                                                      |
+| `--open-tracing-config-file` | Файл конфигурации трассировщика (совместимый с OpenTracing). Смотрите [Отслеживание производительности](/docs/performance-tracing/) |
+| `--no-color`, `--no-colors`  | Отключить цветной вывод на терминал                                                                                                 |
 
 ### `serve`
 
-At the root of a Gatsby site, serve the production build of your site for testing:
+В корневом каталоге сайта Gatsby, запустите продакшен сборку вашего сайта для тестирования:
 
 `gatsby serve`
 
-#### Options
+#### Опции
 
-|      Option      | Description                                                                              |
-| :--------------: | ---------------------------------------------------------------------------------------- |
-|  `-H`, `--host`  | Set host. Defaults to localhost                                                          |
-|  `-p`, `--port`  | Set port. Defaults to 9000                                                               |
-|  `-o`, `--open`  | Open the site in your (default) browser for you                                          |
-| `--prefix-paths` | Serve site with link paths prefixed (if built with pathPrefix in your gatsby-config.js). |
+|      Опция       | Описание                                                                                      |
+| :--------------: | --------------------------------------------------------------------------------------------- |
+|  `-H`, `--host`  | Установить хост. По умолчанию localhost                                                       |
+|  `-p`, `--port`  | Установить порт. По умолчанию 9000                                                            |
+|  `-o`, `--open`  | Открыть сайт в вашем браузере (по умолчанию)                                                  |
+| `--prefix-paths` | Запустить сайт с префиксами путей ссылки (если собран с pathPrefix в вашем gatsby-config.js). |
 
 ### `info`
 
-At the root of a Gatsby site, get helpful environment information which will be required when reporting a bug:
+В корневом каталоге сайта Gatsby, получите полезную информацию об окружении, которая потребуется при сообщении о баге:
 
 `gatsby info`
 
-#### Options
+#### Опции
 
-|       Option        | Description                                             |
-| :-----------------: | ------------------------------------------------------- |
-| `-C`, `--clipboard` | Automagically copy environment information to clipboard |
+|       Опция         | Описание                                                        |
+| :-----------------: | --------------------------------------------------------------- |
+| `-C`, `--clipboard` | Автоматически копировать информацию об окружении в буфер обмена |
 
 ### `clean`
 
-At the root of a Gatsby site, wipe out the cache (`.cache` folder) and public directories:
+В корневом каталоге сайта Gatsby, чтобы стереть кэш (папка `.cache`) и публичные каталоги:
 
 `gatsby clean`
 
-This is useful as a last resort when your local project seems to have issues or content does not seem to be refreshing. Issues this may fix commonly include:
+Это полезно в качестве крайней меры, когда ваш локальный проект, кажется, имеет проблемы или контент не обновляется. Проблемы, которые это может исправить, часто включают:
 
-- Stale data, e.g. this file/resource/etc. isn't appearing
-- GraphQL error, e.g. this GraphQL resource should be present but is not
-- Dependency issues, e.g. invalid version, cryptic errors in console, etc.
-- Plugin issues, e.g. developing a local plugin and changes don't seem to be taking effect
+- Устаревшие данные, например этот файл/ресурс и пр. не появляется
+- Ошибка GraphQL, например, этот ресурс GraphQL должен присутствовать, но его нет
+- Проблемы зависимости, например, неверная версия, загадочные ошибки в консоли и т. д.
+- Проблемы с плагинами, например при разработке локального плагина изменения, похоже, не вступают в силу
 
 ### `plugin`
 
-Run commands pertaining to gatsby plugins.
+Запуск команд, относящихся к плагинам Gatsby.
 
 #### `docs`
 
 `gatsby plugin docs`
 
-Directs you to documentation about using and creating plugins.
+Направляет вас к документации по использованию и созданию плагинов.
 
 ### Repl
 
-Get a Node.js REPL (interactive shell) with context of your Gatsby environment:
+Получить Node.js REPL (интерактивную оболочку) с контекстом среды вашего Gatsby:
 
 `gatsby repl`
 
-Gatsby will prompt you to type in commands and explore. When it shows this: `gatsby >`
+Gatsby предложит вам вводить команды и исследовать. Когда будет показано: `gatsby >`
 
-You can type in a command, such as one of these:
+Вы можете ввести команду, например, одну из следующих:
 
 `babelrc`
 
@@ -161,10 +161,10 @@ You can type in a command, such as one of these:
 
 `staticQueries`
 
-When combined with the [GraphQL explorer](/docs/introducing-graphiql/), these REPL commands could be very helpful for understanding your Gatsby site's data.
+В сочетании с [проводником GraphQL](/docs/introducing-graphiql/), эти REPL команды могут быть очень полезны для понимания данных вашего сайта Gatsby.
 
-See the Gatsby REPL documentation [here](/docs/gatsby-repl/).
+Смотрите документацию Gatsby REPL [здесь](/docs/gatsby-repl/).
 
-### Disabling colored output
+### Отключение цветного вывода
 
-In addition to the explicit `--no-color` option, the CLI respects the presence of the `NO_COLOR` environment variable (see [no-color.org](https://no-color.org/)).
+В дополнение к заданной опции `--no-color`, CLI учитывает наличие переменной среды `NO_COLOR` (смотрите [no-color.org](https://no-color.org/)).


### PR DESCRIPTION
Много терминов. 
Так же замечал места, например: _You can use the Gatsby develop command with the host option_, где на мой взгляд `Gatsby develop` и `host` должны быть взяты в кавычки, но раз в оригинале этого сделано не было, то я просто не стал это переводить, так как это на мой взгляд все таки команда и её параметр.